### PR TITLE
Correct handling of Subchunk2Size (additional header data available or not)

### DIFF
--- a/tinywav.c
+++ b/tinywav.c
@@ -77,11 +77,17 @@ int tinywav_open_read(TinyWav *tw, const char *path, TinyWavChannelFormat chanFm
   assert(tw->h.Subchunk1ID == htonl(0x666d7420));    // "fmt "
   
   // skip over any other chunks before the "data" chunk
+  bool additionalHeaderDataPresent = false;
   while (tw->h.Subchunk2ID != htonl(0x64617461)) {   // "data"
     fseek(tw->f, 4, SEEK_CUR);
     fread(&tw->h.Subchunk2ID, 4, 1, tw->f);
+    additionalHeaderDataPresent = true;
   }
   assert(tw->h.Subchunk2ID == htonl(0x64617461));    // "data"
+  if (additionalHeaderDataPresent) {
+    // read the value of Subchunk2Size, the one populated when reading 'TinyWavHeader' structure is wrong
+    fread(&tw->h.Subchunk2Size, 4, 1, tw->f);
+  }
     
   tw->numChannels = tw->h.NumChannels;
   tw->chanFmt = chanFmt;


### PR DESCRIPTION
This fix enhances a previous change that fixed the code for wave files without additional header.

Both scenarious are working now:
1. Standard wav header (no additional data):   `Subchunk2Size` is populated by the read of `sizeof(TinyWavHeader)` data
2. Wav header with additional data:  `Subchunk2Size` is populated by reading the Subchunk2 header after skipping over the additional data.
