### PR TITLE
tinywav_open_write: use binary mode

### DIFF
--- a/tinywav.c
+++ b/tinywav.c
@@ -184,11 +184,8 @@ int tinywav_write_f(TinyWav *tw, void *f, int len) {
       int16_t *z = (int16_t *) alloca(tw->numChannels*len*sizeof(int16_t));
       switch (tw->chanFmt) {
         case TW_INTERLEAVED: {
-          const float *const x = (const float *const) f;
-          for (int i = 0; i < tw->numChannels*len; ++i) {
-            z[i] = (int16_t) (x[i] * (float) INT16_MAX);
-          }
-          break;
+          tw->totalFramesReadWritten += len;
+          return (int) fwrite(f, sizeof(int16_t), tw->numChannels*len, tw->f);
         }
         case TW_INLINE: {
           const float *const x = (const float *const) f;

--- a/tinywav.c
+++ b/tinywav.c
@@ -33,10 +33,10 @@ int tinywav_open_write(TinyWav *tw,
     TinyWavSampleFormat sampFmt, TinyWavChannelFormat chanFmt,
     const char *path) {
 #if _WIN32
-  errno_t err = fopen_s(&tw->f, path, "w");
+  errno_t err = fopen_s(&tw->f, path, "wb");
   assert(err == 0);
 #else
-  tw->f = fopen(path, "w");
+  tw->f = fopen(path, "wb");
 #endif
   assert(tw->f != NULL);
   tw->numChannels = numChannels;


### PR DESCRIPTION
# Fix method tinywav_open_write
- [x] open file in write binary mode
----------
I was working on a project that involved converting `.raw` audio files produced by portaudio to `.wav` files. However, I noticed that the converted `.wav` files had corrupted audio, while the original `.raw` files played correctly with portaudio. I investigated the issue and found out that the problem was caused by opening the files in text mode (`r`) instead of binary mode (`rb`). After changing the mode to `rb`, the conversion worked as expected.