### PR TITLE
Use return values instead of assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,17 @@
 
 A minimal C library for reading and writing (32-bit float or 16-bit int) WAV audio files. Designed for maximum portability.
 
-* Tinywav takes and provides audio samples in configurable channel formats (interleaved, split, inline). WAV files always store samples in interleaved format.
-* Tinywav is minimal: it can only read/write RIFF WAV files with sample format `float32` or `int16`.
-* Tinywav does not allocate any memory on the heap. It uses `alloca` internally, which allocates on the stack. In practice, this restricts the block size to "reasonable" values, so watch out for stack overflows.
+* TinyWav takes and provides audio samples in configurable channel formats (interleaved, split, inline). WAV files always store samples in interleaved format.
+* TinyWav is minimal: it can only read/write RIFF WAV files with sample format `float32` or `int16`.
+* TinyWav does not allocate any memory on the heap. It uses `alloca` internally, which allocates on the stack. In practice, this restricts the block size to "reasonable" values, so watch out for stack overflows.
 
+**CI/CD**: To guarantee portability, TinyWav is built and tested on several platforms, compilers & architectures:
+
+![](https://img.shields.io/badge/macos-Clang_14-teal)
+![](https://img.shields.io/badge/linux-GCC_7-teal)
+![](https://img.shields.io/badge/linux-GCC_11-teal)
+![](https://img.shields.io/badge/windows-MSVC_VS2022_(x64)-teal)
+![](https://img.shields.io/badge/windows-MSVC_VS2022_(arm64)_[build_only]-teal)
 [![Build & Test](https://github.com/mhroth/tinywav/actions/workflows/workflow.yml/badge.svg?branch=master)](https://github.com/mhroth/tinywav/actions/workflows/workflow.yml)
 
 ## Code Example
@@ -19,7 +26,7 @@ A minimal C library for reading and writing (32-bit float or 16-bit int) WAV aud
 ```c
 #include "tinywav.h"
 
-#define NUM_CHANNELS 1
+#define NUM_CHANNELS 2
 #define SAMPLE_RATE 48000
 #define BLOCK_SIZE 480
 
@@ -78,6 +85,22 @@ for (int i = 0; i < 100; i++) {
 
 tinywav_close_read(&tw);
 ```
+
+## Running the Tests
+
+TinyWav relies on Cmake for its test builds. The automated tests are based on the [Catch2](https://github.com/catchorg/Catch2) C++ test framework.
+
+To run the tests, run one of the generator scripts in the `test/scripts` directory to generate a Xcode/VS project - or directly use Cmake in the commandline:
+
+```bash
+mkdir -p test/scripts/build
+cd test/scripts/build
+cmake ../../..
+make
+ctest # or run ./TinyWavTest directly
+```
+
+> **NOTE**: The Git repository uses Git LFS to store some reference wav files as binaries. Make sure you have Git LFS installed/enabled/pulled before running the tests.
 
 ## License
 TinyWav is published under the [ISC license](http://opensource.org/licenses/ISC). Please see the `LICENSE` file included in this repository, also reproduced below. In short, you are welcome to use this code for any purpose, including commercial and closed-source use.

--- a/test/TestCommon.hpp
+++ b/test/TestCommon.hpp
@@ -9,9 +9,16 @@
 #pragma once
 
 #include <catch2/catch.hpp>
+#include <fstream>
 
 namespace TestCommon
 {
+
+static inline bool fileExists(const std::string& name)
+{
+    std::ifstream f(name.c_str());
+    return f.good();
+}
 
 /** [ABCABCABC] --> [AAABBBCCC] */
 static std::vector<float> deinterleave(std::vector<float> interleavedVector, int numChannels)

--- a/test/tests/BasicTests.cpp
+++ b/test/tests/BasicTests.cpp
@@ -157,10 +157,10 @@ TEST_CASE("Tinywav - Test Error Behaviour")
     REQUIRE(tinywav_open_read(&tw, "bogus.wav", channelFormat) != 0);
     tinywav_close_read(&tw);
     
-    REQUIRE(tinywav_open_write(NULL, -1, -1, TW_FLOAT32, TW_INLINE, NULL) != 0);
-    REQUIRE(tinywav_open_write(&tw, -1, -1, TW_FLOAT32, TW_INLINE, NULL) != 0);
-    REQUIRE(tinywav_open_write(&tw, 2, -1, TW_FLOAT32, TW_INLINE, NULL) != 0);
-    REQUIRE(tinywav_open_write(&tw, 2, -1, TW_FLOAT32, TW_INLINE, "bogus.wav") != 0);
+//    REQUIRE(tinywav_open_write(NULL, -1, -1, TW_FLOAT32, TW_INLINE, NULL) != 0);
+//    REQUIRE(tinywav_open_write(&tw, -1, -1, TW_FLOAT32, TW_INLINE, NULL) != 0);
+//    REQUIRE(tinywav_open_write(&tw, 2, -1, TW_FLOAT32, TW_INLINE, NULL) != 0);
+//    REQUIRE(tinywav_open_write(&tw, 2, -1, TW_FLOAT32, TW_INLINE, "bogus.wav") != 0);
   }
   
   SECTION("Test _write_f") {

--- a/test/tests/BasicTests.cpp
+++ b/test/tests/BasicTests.cpp
@@ -148,7 +148,7 @@ TEST_CASE("Tinywav - Test Error Behaviour")
   TinyWav tw;
   
   if (TestCommon::fileExists("bogus.wav")) {
-    REQUIRE(remove("bogus.wav") == 0);
+    REQUIRE(std::remove("bogus.wav") == 0);
   }
   
   SECTION("Test _open_ functions") {
@@ -173,10 +173,6 @@ TEST_CASE("Tinywav - Test Error Behaviour")
     REQUIRE(tinywav_write_f(&tw, buffer, 0) == 0);
     REQUIRE(tinywav_write_f(&tw, buffer, 16) == 16);
     REQUIRE(tinywav_write_f(&tw, buffer, 23) == 23);
-  
-    if (TestCommon::fileExists("bogus.wav")) {
-        REQUIRE(remove("bogus.wav") == 0);
-    }
   }
   
   SECTION("Test _read_f") {
@@ -205,10 +201,6 @@ TEST_CASE("Tinywav - Test Error Behaviour")
     REQUIRE(tinywav_read_f(&tw, buffer, numSamples-16-1) == numSamples-16-1); // leave one sample unread
     REQUIRE(tinywav_read_f(&tw, buffer, 1) == 1); // last sample
     REQUIRE(tinywav_read_f(&tw, buffer, 1) == 0); // no more data available
-    
-    if (TestCommon::fileExists("bogus.wav")) {
-        REQUIRE(remove("bogus.wav") == 0);
-    }
   }
   
 }

--- a/test/tests/BasicTests.cpp
+++ b/test/tests/BasicTests.cpp
@@ -157,10 +157,10 @@ TEST_CASE("Tinywav - Test Error Behaviour")
     REQUIRE(tinywav_open_read(&tw, "bogus.wav", channelFormat) != 0);
     tinywav_close_read(&tw);
     
-//    REQUIRE(tinywav_open_write(NULL, -1, -1, TW_FLOAT32, TW_INLINE, NULL) != 0);
-//    REQUIRE(tinywav_open_write(&tw, -1, -1, TW_FLOAT32, TW_INLINE, NULL) != 0);
-//    REQUIRE(tinywav_open_write(&tw, 2, -1, TW_FLOAT32, TW_INLINE, NULL) != 0);
-//    REQUIRE(tinywav_open_write(&tw, 2, -1, TW_FLOAT32, TW_INLINE, "bogus.wav") != 0);
+    REQUIRE(tinywav_open_write(NULL, -1, -1, TW_FLOAT32, TW_INLINE, NULL) != 0);
+    REQUIRE(tinywav_open_write(&tw, -1, -1, TW_FLOAT32, TW_INLINE, NULL) != 0);
+    REQUIRE(tinywav_open_write(&tw, 2, -1, TW_FLOAT32, TW_INLINE, NULL) != 0);
+    REQUIRE(tinywav_open_write(&tw, 2, -1, TW_FLOAT32, TW_INLINE, "bogus.wav") != 0);
   }
   
   SECTION("Test _write_f") {

--- a/test/tests/BasicTests.cpp
+++ b/test/tests/BasicTests.cpp
@@ -161,7 +161,6 @@ TEST_CASE("Tinywav - Test Error Behaviour")
     REQUIRE(tinywav_open_write(&tw, -1, -1, TW_FLOAT32, TW_INLINE, NULL) != 0);
     REQUIRE(tinywav_open_write(&tw, 2, -1, TW_FLOAT32, TW_INLINE, NULL) != 0);
     REQUIRE(tinywav_open_write(&tw, 2, -1, TW_FLOAT32, TW_INLINE, "bogus.wav") != 0);
-    tinywav_close_write(&tw);
   }
   
   SECTION("Test _write_f") {

--- a/test/tests/BasicTests.cpp
+++ b/test/tests/BasicTests.cpp
@@ -25,6 +25,10 @@ TEST_CASE("Tinywav - Basic Reading/Writing Loop", "aka Eat Your Own Dog Food")
 
   const char* testFile = "testFile.wav";
 
+  if (TestCommon::fileExists(testFile)) {
+      REQUIRE(remove(testFile) == 0);
+  }
+
   TinyWavSampleFormat sampleFormat = GENERATE(TW_FLOAT32, TW_INT16);
   TinyWavChannelFormat channelFormatW = GENERATE(TW_INTERLEAVED, TW_INLINE, TW_SPLIT);
   TinyWavChannelFormat channelFormatR = GENERATE(TW_INTERLEAVED, TW_INLINE, TW_SPLIT);
@@ -143,6 +147,10 @@ TEST_CASE("Tinywav - Test Error Behaviour")
   TinyWavChannelFormat channelFormat = GENERATE(TW_INTERLEAVED, TW_INLINE, TW_SPLIT);
   TinyWav tw;
   
+  if (TestCommon::fileExists("bogus.wav")) {
+    REQUIRE(remove("bogus.wav") == 0);
+  }
+  
   SECTION("Test _open_ functions") {
     REQUIRE(tinywav_open_read(NULL, NULL, channelFormat) != 0);
     REQUIRE(tinywav_open_read(NULL, "bogus.wav", channelFormat) != 0);
@@ -166,7 +174,9 @@ TEST_CASE("Tinywav - Test Error Behaviour")
     REQUIRE(tinywav_write_f(&tw, buffer, 16) == 16);
     REQUIRE(tinywav_write_f(&tw, buffer, 23) == 23);
   
-    REQUIRE(remove("bogus.wav") == 0);
+    if (TestCommon::fileExists("bogus.wav")) {
+        REQUIRE(remove("bogus.wav") == 0);
+    }
   }
   
   SECTION("Test _read_f") {
@@ -196,7 +206,9 @@ TEST_CASE("Tinywav - Test Error Behaviour")
     REQUIRE(tinywav_read_f(&tw, buffer, 1) == 1); // last sample
     REQUIRE(tinywav_read_f(&tw, buffer, 1) == 0); // no more data available
     
-    REQUIRE(remove("bogus.wav") == 0);
+    if (TestCommon::fileExists("bogus.wav")) {
+        REQUIRE(remove("bogus.wav") == 0);
+    }
   }
   
 }

--- a/test/tests/BasicTests.cpp
+++ b/test/tests/BasicTests.cpp
@@ -155,11 +155,13 @@ TEST_CASE("Tinywav - Test Error Behaviour")
     REQUIRE(tinywav_open_read(NULL, NULL, channelFormat) != 0);
     REQUIRE(tinywav_open_read(NULL, "bogus.wav", channelFormat) != 0);
     REQUIRE(tinywav_open_read(&tw, "bogus.wav", channelFormat) != 0);
+    tinywav_close_read(&tw);
     
     REQUIRE(tinywav_open_write(NULL, -1, -1, TW_FLOAT32, TW_INLINE, NULL) != 0);
     REQUIRE(tinywav_open_write(&tw, -1, -1, TW_FLOAT32, TW_INLINE, NULL) != 0);
     REQUIRE(tinywav_open_write(&tw, 2, -1, TW_FLOAT32, TW_INLINE, NULL) != 0);
     REQUIRE(tinywav_open_write(&tw, 2, -1, TW_FLOAT32, TW_INLINE, "bogus.wav") != 0);
+    tinywav_close_write(&tw);
   }
   
   SECTION("Test _write_f") {
@@ -173,6 +175,8 @@ TEST_CASE("Tinywav - Test Error Behaviour")
     REQUIRE(tinywav_write_f(&tw, buffer, 0) == 0);
     REQUIRE(tinywav_write_f(&tw, buffer, 16) == 16);
     REQUIRE(tinywav_write_f(&tw, buffer, 23) == 23);
+    
+    tinywav_close_write(&tw);
   }
   
   SECTION("Test _read_f") {
@@ -201,6 +205,8 @@ TEST_CASE("Tinywav - Test Error Behaviour")
     REQUIRE(tinywav_read_f(&tw, buffer, numSamples-16-1) == numSamples-16-1); // leave one sample unread
     REQUIRE(tinywav_read_f(&tw, buffer, 1) == 1); // last sample
     REQUIRE(tinywav_read_f(&tw, buffer, 1) == 0); // no more data available
+    
+    tinywav_close_read(&tw);
   }
   
 }

--- a/test/tests/BasicTests.cpp
+++ b/test/tests/BasicTests.cpp
@@ -190,7 +190,8 @@ TEST_CASE("Tinywav - Test Error Behaviour")
     REQUIRE(tinywav_read_f(&tw, buffer, -1) != 0);
     REQUIRE(tinywav_read_f(&tw, buffer, 0) == 0);
     REQUIRE(tinywav_read_f(&tw, buffer, 16) == 0); // no data in file yet!
-    
+    tinywav_close_read(&tw);
+
     // Test data
     constexpr int numSamples = 64;
     const std::vector<float> testData = TestCommon::createRandomVector(numChannels*numSamples);

--- a/tinywav.c
+++ b/tinywav.c
@@ -32,7 +32,7 @@ int tinywav_open_write(TinyWav *tw, int16_t numChannels, int32_t samplerate, Tin
     return -1;
   }
   
-#if 0// _WIN32
+#if _WIN32
   errno_t err = fopen_s(&tw->f, path, "wb");
   if (err != 0) { return err; }
 #else
@@ -77,7 +77,7 @@ int tinywav_open_read(TinyWav *tw, const char *path, TinyWavChannelFormat chanFm
     return -1;
   }
   
-#if 0//_WIN32
+#if _WIN32
   errno_t err = fopen_s(&tw->f, path, "rb");
   if (err != 0) { return err; }
 #else

--- a/tinywav.c
+++ b/tinywav.c
@@ -28,6 +28,10 @@
 int tinywav_open_write(TinyWav *tw, int16_t numChannels, int32_t samplerate, TinyWavSampleFormat sampFmt,
                        TinyWavChannelFormat chanFmt, const char *path) {
   
+  if (tw == NULL || path == NULL || numChannels < 1 || samplerate < 1) {
+    return -1;
+  }
+  
 #if _WIN32
   errno_t err = fopen_s(&tw->f, path, "wb");
   if (err != 0) { return err; }
@@ -68,6 +72,10 @@ int tinywav_open_write(TinyWav *tw, int16_t numChannels, int32_t samplerate, Tin
 }
 
 int tinywav_open_read(TinyWav *tw, const char *path, TinyWavChannelFormat chanFmt) {
+  
+  if (tw == NULL || path == NULL) {
+    return -1;
+  }
   
 #if _WIN32
   errno_t err = fopen_s(&tw->f, path, "rb");
@@ -129,6 +137,11 @@ int tinywav_open_read(TinyWav *tw, const char *path, TinyWavChannelFormat chanFm
 }
 
 int tinywav_read_f(TinyWav *tw, void *data, int len) {
+  
+  if (tw == NULL || data == NULL || len < 0) {
+    return -1;
+  }
+  
   switch (tw->sampFmt) {
     case TW_INT16: {
       int16_t *interleaved_data = (int16_t *) alloca(tw->numChannels*len*sizeof(int16_t));
@@ -200,6 +213,14 @@ void tinywav_close_read(TinyWav *tw) {
 }
 
 int tinywav_write_f(TinyWav *tw, void *f, int len) {
+  
+  if (tw == NULL || f == NULL || len < 0) {
+    return -1;
+  }
+  
+  // 1. Bring samples into interleaved format
+  // 2. write to disk
+  
   switch (tw->sampFmt) {
     case TW_INT16: {
       int16_t *z = (int16_t *) alloca(tw->numChannels*len*sizeof(int16_t));

--- a/tinywav.c
+++ b/tinywav.c
@@ -91,6 +91,7 @@ int tinywav_open_read(TinyWav *tw, const char *path, TinyWavChannelFormat chanFm
   // TODO: portability: do not use sizeof(TinyWavHeader) -- struct packing! Read bytes individually
   size_t read_elements = fread(&tw->h, sizeof(TinyWavHeader), 1, tw->f);
   if (read_elements < 1) {
+    tinywav_close_read(tw);
     return -1;
   }
   
@@ -99,6 +100,7 @@ int tinywav_open_read(TinyWav *tw, const char *path, TinyWavChannelFormat chanFm
     //htonl(0x52494646) "RIFF"
     //htonl(0x57415645) "WAVE"
     //htonl(0x666d7420) "fmt "
+    tinywav_close_read(tw);
     return -1;
   }
   
@@ -110,6 +112,7 @@ int tinywav_open_read(TinyWav *tw, const char *path, TinyWavChannelFormat chanFm
     additionalHeaderDataPresent = true;
   }
   if (tw->h.Subchunk2ID != htonl(0x64617461)) {  // "data"
+    tinywav_close_read(tw);
     return -1;
   }
   

--- a/tinywav.c
+++ b/tinywav.c
@@ -32,7 +32,7 @@ int tinywav_open_write(TinyWav *tw, int16_t numChannels, int32_t samplerate, Tin
     return -1;
   }
   
-#if _WIN32
+#if 0// _WIN32
   errno_t err = fopen_s(&tw->f, path, "wb");
   if (err != 0) { return err; }
 #else
@@ -77,7 +77,7 @@ int tinywav_open_read(TinyWav *tw, const char *path, TinyWavChannelFormat chanFm
     return -1;
   }
   
-#if _WIN32
+#if 0//_WIN32
   errno_t err = fopen_s(&tw->f, path, "rb");
   if (err != 0) { return err; }
 #else

--- a/tinywav.c
+++ b/tinywav.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015-2022, Martin Roth (mhroth@gmail.com)
+ * Copyright (c) 2015-2023, Martin Roth (mhroth@gmail.com)
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -34,12 +34,13 @@ int tinywav_open_write(TinyWav *tw, int16_t numChannels, int32_t samplerate, Tin
   
 #if _WIN32
   errno_t err = fopen_s(&tw->f, path, "wb");
-  if (err != 0) { return err; }
+  if (err != 0) { tw->f == NULL; }
 #else
   tw->f = fopen(path, "wb");
 #endif
   
   if (tw->f == NULL) {
+    perror("[tinywav] Failed to open file for writing");
     return -1;
   }
 
@@ -79,12 +80,13 @@ int tinywav_open_read(TinyWav *tw, const char *path, TinyWavChannelFormat chanFm
   
 #if _WIN32
   errno_t err = fopen_s(&tw->f, path, "rb");
-  if (err != 0) { return err; }
+  if (err != 0) { tw->f == NULL; }
 #else
   tw->f = fopen(path, "rb");
 #endif
   
   if (tw->f == NULL) {
+    perror("[tinywav] Failed to open file for reading");
     return -1;
   }
   
@@ -132,7 +134,7 @@ int tinywav_open_read(TinyWav *tw, const char *path, TinyWavChannelFormat chanFm
     tw->sampFmt = TW_INT16; // file has 16-bit int samples
   } else {
     tw->sampFmt = TW_FLOAT32;
-    printf("Warning: wav file has %d bits per sample (int), which is not natively supported yet. Treating them as float; you may want to convert them manually after reading.\n", tw->h.BitsPerSample);
+    printf("[tinywav] Warning: wav file has %d bits per sample (int), which is not natively supported yet. Treating them as float; you may want to convert them manually after reading.\n", tw->h.BitsPerSample);
   }
 
   tw->numFramesInHeader = tw->h.Subchunk2Size / (tw->numChannels * tw->sampFmt);

--- a/tinywav.h
+++ b/tinywav.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015-2022, Martin Roth (mhroth@gmail.com)
+ * Copyright (c) 2015-2023, Martin Roth (mhroth@gmail.com)
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above


### PR DESCRIPTION
Assertions are useful for quick n' dirty stuff, but using the return values gives runtime control when handling errors.
Since the function documentation already uses return values, I assume this is how things were originally intended.

Thanks to http://github.com/pslack for some of the code snippets used here.
