### PR TITLE
Added alternatives to 'alloca' for allocation 

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -4,19 +4,19 @@ on:
 jobs:
   build:
     name: Linux, ${{matrix.cxx}}, C++${{matrix.std}}, ${{matrix.build_type}}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         cxx:
-          - g++-7
+          - g++-8
           - g++-11
         build_type: [Debug, Release]
         std: [14]
         include:
-          - cxx: g++-7
-            cc: gcc-7
-            other_pkgs: g++-7 gcc-7
+          - cxx: g++-8
+            cc: gcc-8
+            other_pkgs: g++-8 gcc-8
           - cxx: g++-11
             cc: gcc-11
             other_pkgs: g++-11 gcc-11

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
 jobs:
   build:
-    name: Linux, ${{matrix.cxx}}, C++${{matrix.std}}, ${{matrix.build_type}}
+    name: Linux, ${{matrix.cxx}}, ${{matrix.tinywav_options}}, ${{matrix.build_type}}
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -13,6 +13,7 @@ jobs:
           - g++-11
         build_type: [Debug, Release]
         std: [14]
+        tinywav_options: [ALLOCA, MALLOC, VLA]
         include:
           - cxx: g++-8
             cc: gcc-8
@@ -39,6 +40,7 @@ jobs:
         cd build
         cmake -DCMAKE_CXX_STANDARD=${{matrix.std}} \
               -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
+              -DTINYWAV_ALLOCATION=${{matrix.tinywav_options}} \
               ..
         
     - name: Build & Run Tests

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -9,15 +9,15 @@ jobs:
       fail-fast: false
       matrix:
         cxx:
-          - g++-8
+          - g++-9
           - g++-11
         build_type: [Debug, Release]
         std: [14]
         tinywav_options: [ALLOCA, MALLOC, VLA]
         include:
-          - cxx: g++-8
-            cc: gcc-8
-            other_pkgs: g++-8 gcc-8
+          - cxx: g++-9
+            cc: gcc-9
+            other_pkgs: g++-9 gcc-9
           - cxx: g++-11
             cc: gcc-11
             other_pkgs: g++-11 gcc-11

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
 jobs:
   build:
-    name: ${{matrix.os}}, ${{matrix.cxx}}, C++${{matrix.std}}, ${{matrix.build_type}}
+    name: ${{matrix.os}}, ${{matrix.cxx}}, ${{matrix.tinywav_options}}, ${{matrix.build_type}}
     runs-on: ${{matrix.os}}
     strategy:
       fail-fast: false

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -9,6 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-11]
+        tinywav_options: [ALLOCA, MALLOC, VLA]
         cxx:
           - clang++
         build_type: [Debug, Release]
@@ -27,6 +28,7 @@ jobs:
         cd build
         cmake -DCMAKE_CXX_STANDARD=${{matrix.std}} \
               -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
+              -DTINYWAV_ALLOCATION=${{matrix.tinywav_options}} \
               ..
         
     - name: Build & Run Tests

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11]
+        os: [macos-13]
         tinywav_options: [ALLOCA, MALLOC, VLA]
         cxx:
           - clang++

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -24,7 +24,7 @@ jobs:
           cd build
           cmake -DCMAKE_BUILD_TYPE=${{matrix.build_type}} `
                 -DCMAKE_CXX_STANDARD=${{matrix.std}} `
-                -DTINYWAV_ALLOCATION=${{matrix.tinywav_options}} ``
+                -DTINYWAV_ALLOCATION=${{matrix.tinywav_options}} `
                 -A ${{matrix.platform}} `
                 ..
             

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
 jobs:
   build:
-    name: ${{matrix.os}}, MSVC, C++${{matrix.std}}, ${{matrix.build_type}}, ${{matrix.platform}}
+    name: ${{matrix.os}}, MSVC, ${{matrix.tinywav_options}}, ${{matrix.build_type}}, ${{matrix.platform}}
     runs-on: ${{matrix.os}}
     strategy:
       fail-fast: false
@@ -24,6 +24,7 @@ jobs:
           cd build
           cmake -DCMAKE_BUILD_TYPE=${{matrix.build_type}} `
                 -DCMAKE_CXX_STANDARD=${{matrix.std}} `
+                -DTINYWAV_ALLOCATION=${{matrix.tinywav_options}} ``
                 -A ${{matrix.platform}} `
                 ..
             

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -12,6 +12,7 @@ jobs:
         platform: [x64, arm64]
         build_type: [Debug, Release]
         std: [14]
+        tinywav_options: [ALLOCA, MALLOC] # VLA not supported with MSVC
     steps:
       - uses: actions/checkout@v4
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,26 @@ set(CMAKE_CXX_STANDARD 14)
 set(CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# Cmake options
+set(TINYWAV_ALLOCATION "ALLOCA" CACHE STRING "Configure tinywav's method of allocation")
+set_property(CACHE TINYWAV_ALLOCATION PROPERTY STRINGS ALLOCA VLA MALLOC)
+
+# Source files
 file(GLOB source_files "tinywav.c" "tinywav.h")
 add_library(${PROJECT_NAME} ${source_files})
+
+if (TINYWAV_ALLOCATION MATCHES "ALLOCA")
+  message(STATUS "Configuring tinywav to use ALLOCA for allocations")
+  target_compile_definitions(${PROJECT_NAME} PRIVATE TINYWAV_USE_ALLOCA=1)
+elseif(TINYWAV_ALLOCATION MATCHES "VLA")
+  message(STATUS "Configuring tinywav to use VLA for allocations")
+  target_compile_definitions(${PROJECT_NAME} PRIVATE TINYWAV_USE_VLA=1)
+elseif(TINYWAV_ALLOCATION MATCHES "MALLOC")
+  message(STATUS "Configuring tinywav to use MALLOC for allocations")
+  target_compile_definitions(${PROJECT_NAME} PRIVATE TINYWAV_USE_MALLOC=1)
+else()
+  message(FATAL_ERROR "Invalid option for TINYWAV_ALLOCATION -- valid options are: ALLOCA VLA MALLOC")
+endif()
 
 # TEST TARGET
 set(TEST_NAME "${PROJECT_NAME}Test")

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A minimal C library for reading and writing (32-bit float or 16-bit int) WAV aud
 * TinyWav takes and provides audio samples in configurable channel formats (interleaved, split, inline). WAV files always store samples in interleaved format.
 * TinyWav is minimal: it can only read/write RIFF WAV files with sample format `float32` or `int16`.
 * TinyWav does not allocate any memory on the heap. It uses `alloca` internally, which allocates on the stack. In practice, this restricts the block size to "reasonable" values, so watch out for stack overflows.
+   * On platforms where `alloca` is not available (e.g. some DSP compilers), `TINYWAV_USE_VLA` or `TINYWAV_USE_MALLOC` can be defined.
 
 **CI/CD**: To guarantee portability, TinyWav is built and tested on several platforms, compilers & architectures:
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A minimal C library for reading and writing (32-bit float or 16-bit int) WAV aud
 **CI/CD**: To guarantee portability, TinyWav is built and tested on several platforms, compilers & architectures:
 
 ![](https://img.shields.io/badge/macos-Clang_14-teal)
-![](https://img.shields.io/badge/linux-GCC_7-teal)
+![](https://img.shields.io/badge/linux-GCC_9-teal)
 ![](https://img.shields.io/badge/linux-GCC_11-teal)
 ![](https://img.shields.io/badge/windows-MSVC_VS2022_(x64)-teal)
 ![](https://img.shields.io/badge/windows-MSVC_VS2022_(arm64)_[build_only]-teal)

--- a/tinywav.c
+++ b/tinywav.c
@@ -22,10 +22,12 @@
     #define TINYWAV_USE_ALLOCA 1 // default
 #endif
 
-#if TINYWAV_USE_MALLOC || (defined(_WIN32) && TINYWAV_USE_ALLOCA)
+#if defined(_WIN32) && (TINYWAV_USE_ALLOCA || TINYWAV_USE_MALLOC)
   #include <malloc.h>
 #elif TINYWAV_USE_ALLOCA
   #include <alloca.h>
+#elif TINYWAV_USE_MALLOC
+  #include <stdlib.h>
 #elif TINYWAV_USE_VLA
     #if _MSC_VER && (__STDC__ || __STDC_NO_VLA__)
         #pragma message ("Cannot use VLA -- MSVC is not a C99-compliant compiler!")
@@ -35,15 +37,15 @@
 #endif
 
 #if TINYWAV_USE_ALLOCA
-    #define TW_ALLOC(type, var, sz) type* var = (type*) alloca(sz*sizeof(type))
+    #define TW_ALLOC(type, var, sz) type* var = (type*) alloca((sz)*sizeof(type))
 #elif TINYWAV_USE_VLA
-    #define TW_ALLOC(type, var, sz) type var[sz]
+    #define TW_ALLOC(type, var, sz) type var[(sz)]
 #elif TINYWAV_USE_MALLOC
-    #define TW_ALLOC(type, var, sz) type* s = (type*) malloc(sz*sizeof(type))
+    #define TW_ALLOC(type, var, sz) type* var = (type*) malloc((sz)*sizeof(type))
 #endif
 
 #if TINYWAV_USE_MALLOC
-    #define TW_DEALLOC(x) (free(x))
+    #define TW_DEALLOC(x) free(x)
 #else
     #define TW_DEALLOC(x)
 #endif

--- a/tinywav.c
+++ b/tinywav.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015-2023, Martin Roth (mhroth@gmail.com)
+ * Copyright (c) 2015-2024	, Martin Roth (mhroth@gmail.com)
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above

--- a/tinywav.c
+++ b/tinywav.c
@@ -15,12 +15,40 @@
  */
 
 #include <string.h> // for memcpy
-#if _WIN32
-#include <malloc.h> // for alloca
-#else
-#include <alloca.h>
-#endif
 #include "tinywav.h"
+
+// MARK: Processor Helpers
+#if !defined(TINYWAV_USE_ALLOCA) && !defined(TINYWAV_USE_VLA) && !defined(TINYWAV_USE_MALLOC)
+    #define TINYWAV_USE_ALLOCA 1 // default
+#endif
+
+#if TINYWAV_USE_MALLOC || (defined(_WIN32) && TINYWAV_USE_ALLOCA)
+  #include <malloc.h>
+#elif TINYWAV_USE_ALLOCA
+  #include <alloca.h>
+#elif TINYWAV_USE_VLA
+    #if _MSC_VER && (__STDC__ || __STDC_NO_VLA__)
+        #pragma message ("Cannot use VLA -- MSVC is not a C99-compliant compiler!")
+    #elif defined(__STDC__) && (__STDC_VERSION__ < 199901L)
+        #error Cannot use VLA -- C standard must be at least C99 / have VLA support!
+    #endif
+#endif
+
+#if TINYWAV_USE_ALLOCA
+    #define TW_ALLOC(type, var, sz) type* var = (type*) alloca(sz*sizeof(type))
+#elif TINYWAV_USE_VLA
+    #define TW_ALLOC(type, var, sz) type var[sz]
+#elif TINYWAV_USE_MALLOC
+    #define TW_ALLOC(type, var, sz) type* s = (type*) malloc(sz*sizeof(type))
+#endif
+
+#if TINYWAV_USE_MALLOC
+    #define TW_DEALLOC(x) (free(x))
+#else
+    #define TW_DEALLOC(x)
+#endif
+
+// MARK: private functions
 
 /** @returns true if the chunk of 4 characters matches the supplied string */
 static bool chunkIDMatches(char chunk[4], const char* chunkName)
@@ -32,6 +60,8 @@ static bool chunkIDMatches(char chunk[4], const char* chunkName)
   }
   return true;
 }
+
+// MARK: public functions
 
 int tinywav_open_write(TinyWav *tw, int16_t numChannels, int32_t samplerate, TinyWavSampleFormat sampFmt,
                        TinyWavChannelFormat chanFmt, const char *path) {
@@ -205,7 +235,7 @@ int tinywav_read_f(TinyWav *tw, void *data, int len) {
   
   switch (tw->sampFmt) {
     case TW_INT16: {
-      int16_t *interleaved_data = (int16_t *) alloca(tw->numChannels*len*sizeof(int16_t));
+      TW_ALLOC(int16_t, interleaved_data, tw->numChannels*len);
       size_t samples_read = fread(interleaved_data, sizeof(int16_t), tw->numChannels*len, tw->f);
       tw->totalFramesReadWritten += samples_read / tw->numChannels;
       int frames_read = (int) samples_read / tw->numChannels;
@@ -234,9 +264,10 @@ int tinywav_read_f(TinyWav *tw, void *data, int len) {
         }
         default: return 0;
       }
+      TW_DEALLOC(interleaved_data);
     }
     case TW_FLOAT32: {
-      float *interleaved_data = (float *) alloca(tw->numChannels*len*sizeof(float));
+      TW_ALLOC(float, interleaved_data, tw->numChannels*len);
       size_t samples_read = fread(interleaved_data, sizeof(float), tw->numChannels*len, tw->f);
       tw->totalFramesReadWritten += samples_read / tw->numChannels;
       int frames_read = (int) samples_read / tw->numChannels;
@@ -263,6 +294,7 @@ int tinywav_read_f(TinyWav *tw, void *data, int len) {
         }
         default: return 0;
       }
+      TW_DEALLOC(interleaved_data);
     }
     default: return 0;
   }
@@ -288,7 +320,7 @@ int tinywav_write_f(TinyWav *tw, void *f, int len) {
   
   switch (tw->sampFmt) {
     case TW_INT16: {
-      int16_t *z = (int16_t *) alloca(tw->numChannels*len*sizeof(int16_t));
+      TW_ALLOC(int16_t, z, tw->numChannels*len);
       switch (tw->chanFmt) {
         case TW_INTERLEAVED: {
           const float *const x = (const float *const) f;
@@ -321,10 +353,11 @@ int tinywav_write_f(TinyWav *tw, void *f, int len) {
       size_t samples_written = fwrite(z, sizeof(int16_t), tw->numChannels*len, tw->f);
       size_t frames_written = samples_written / tw->numChannels;
       tw->totalFramesReadWritten += frames_written;
+      TW_DEALLOC(z);
       return (int) frames_written;
     }
     case TW_FLOAT32: {
-      float *z = (float *) alloca(tw->numChannels*len*sizeof(float));
+      TW_ALLOC(float, z, tw->numChannels*len);
       switch (tw->chanFmt) {
         case TW_INTERLEAVED: {
           const float *const x = (const float *const) f;
@@ -357,6 +390,7 @@ int tinywav_write_f(TinyWav *tw, void *f, int len) {
       size_t samples_written = fwrite(z, sizeof(float), tw->numChannels*len, tw->f);
       size_t frames_written = samples_written / tw->numChannels;
       tw->totalFramesReadWritten += frames_written;
+      TW_DEALLOC(z);
       return (int) frames_written;
     }
     default: return 0;

--- a/tinywav.h
+++ b/tinywav.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015-2023, Martin Roth (mhroth@gmail.com)
+ * Copyright (c) 2015-2024, Martin Roth (mhroth@gmail.com)
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above


### PR DESCRIPTION
Users can now choose between alloca, malloc and variable-length arrays (VLA).
- Cmake option: TINYWAV_ALLOCATION={ALLOCA, VLA, MALLOC}
- Preprocessor defines: TINYWAV_USE_ALLOCA, TINYWAV_USE_VLA, TINYWAV_USE_MALLOC

- VLA is not supported by MSVC.
- alloca/malloc are not available on some plartforms, e.g. embedded/DSP compilers

Github actions changes:
- Ubuntu 20.04 with gcc7 -> 22.04 with gcc9
- macos 11 -> macos 13